### PR TITLE
Remove pam_systemd.so from Ubuntu 16.04

### DIFF
--- a/data/os/Ubuntu/16.04.yaml
+++ b/data/os/Ubuntu/16.04.yaml
@@ -29,4 +29,3 @@ pam::pam_session_lines:
   - 'session required      pam_permit.so'
   - 'session optional      pam_umask.so'
   - 'session required      pam_unix.so'
-  - 'session optional      pam_systemd.so'

--- a/spec/fixtures/ubuntu-16.04-x86_64-pam_common_session
+++ b/spec/fixtures/ubuntu-16.04-x86_64-pam_common_session
@@ -5,4 +5,3 @@ session requisite     pam_deny.so
 session required      pam_permit.so
 session optional      pam_umask.so
 session required      pam_unix.so
-session optional      pam_systemd.so

--- a/spec/fixtures/ubuntu-16.04-x86_64-pam_common_session_noninteractive
+++ b/spec/fixtures/ubuntu-16.04-x86_64-pam_common_session_noninteractive
@@ -5,4 +5,3 @@ session requisite     pam_deny.so
 session required      pam_permit.so
 session optional      pam_umask.so
 session required      pam_unix.so
-session optional      pam_systemd.so


### PR DESCRIPTION
Module does not exist bu default on Ubuntu 16.04. However it can be provided by libpam-systemd.

It was not installed by default on my test system. Will try again and see when I install a real vanilla Ubuntu 16.04.